### PR TITLE
Removed extra space after "Used%".

### DIFF
--- a/src/banks_print.c
+++ b/src/banks_print.c
@@ -176,9 +176,9 @@ static void bank_print_info(bank_item *p_bank) {
                                       p_bank->end); // Address Start -> End
     fprintf(stdout,"%7d", p_bank->size_total);      // Total size
     fprintf(stdout,"%7d", p_bank->size_used);       // Used
-    fprintf(stdout,"  %3d%%", (p_bank->size_used * (uint32_t)100)
+    fprintf(stdout,"  %4d%%", (p_bank->size_used * (uint32_t)100)
                                / p_bank->size_total); // Percent Used
-    fprintf(stdout,"%8d", (int32_t)p_bank->size_total - (int32_t)p_bank->size_used); // Free
+    fprintf(stdout,"%7d", (int32_t)p_bank->size_total - (int32_t)p_bank->size_used); // Free
     fprintf(stdout,"   %3d%%", (((int32_t)p_bank->size_total - (int32_t)p_bank->size_used) * (int32_t)100)
                                / (int32_t)p_bank->size_total); // Percent Free
 

--- a/src/banks_print.c
+++ b/src/banks_print.c
@@ -29,7 +29,7 @@ static void print_graph_char_asciistyle(uint32_t perc_used) {
     #ifdef __WIN32__
         // https://en.wikipedia.org/wiki/Code_page_437
         // https://sourceforge.net/p/mingw/mailman/message/14065664/
-        // Code Page 437 (appears to be default for windows console, 
+        // Code Page 437 (appears to be default for windows console,
         if      (perc_used >= 95) fprintf(stdout, "%c", 219u); // Full  Shade Block
         else if (perc_used >= 75) fprintf(stdout, "%c", 178u); // Dark  Shade Block
         else if (perc_used >= 50) fprintf(stdout, "%c", 177u); // Med   Shade Block
@@ -200,7 +200,7 @@ void banklist_printall(list_type * p_bank_list) {
     int b;
 
     fprintf(stdout, "\n");
-    fprintf(stdout,"Bank           Range             Size   Used   Used%%   Free  Free%% \n"
+    fprintf(stdout,"Bank           Range             Size   Used   Used%%  Free   Free%% \n"
                    "----------     ----------------  -----  -----  -----  -----  -----\n");
 
     // Print all banks


### PR DESCRIPTION
I noticed while making some changes for my own use that the "Free" after "Used%" was one character off, probably because of the escaped % sign.