### PR TITLE
Added compact output option.

### DIFF
--- a/src/banks_print.c
+++ b/src/banks_print.c
@@ -171,13 +171,19 @@ static void bank_print_area(bank_item *p_bank) {
 
 static void bank_print_info(bank_item *p_bank) {
 
-    fprintf(stdout,"%-15s",p_bank->name);           // Name
-    fprintf(stdout,"0x%04X -> 0x%04X",p_bank->start,
-                                      p_bank->end); // Address Start -> End
-    fprintf(stdout,"%7d", p_bank->size_total);      // Total size
-    fprintf(stdout,"%7d", p_bank->size_used);       // Used
-    fprintf(stdout,"  %4d%%", (p_bank->size_used * (uint32_t)100)
-                               / p_bank->size_total); // Percent Used
+    fprintf(stdout,"%-15s",p_bank->name); // Name
+
+    // Skip some info if compact mode is enabled.
+    if (!option_compact_mode) {
+        fprintf(stdout,"0x%04X -> 0x%04X",p_bank->start,
+                                          p_bank->end); // Address Start -> End
+        fprintf(stdout,"%7d", p_bank->size_total);      // Total size
+    }
+    fprintf(stdout,"%7d", p_bank->size_used); // Used
+    if (!option_compact_mode) {
+        fprintf(stdout,"  %4d%%", (p_bank->size_used * (uint32_t)100)
+                                   / p_bank->size_total); // Percent Used
+    }
     fprintf(stdout,"%7d", (int32_t)p_bank->size_total - (int32_t)p_bank->size_used); // Free
     fprintf(stdout,"   %3d%%", (((int32_t)p_bank->size_total - (int32_t)p_bank->size_used) * (int32_t)100)
                                / (int32_t)p_bank->size_total); // Percent Free
@@ -200,8 +206,13 @@ void banklist_printall(list_type * p_bank_list) {
     int b;
 
     fprintf(stdout, "\n");
-    fprintf(stdout,"Bank           Range             Size   Used   Used%%  Free   Free%% \n"
-                   "----------     ----------------  -----  -----  -----  -----  -----\n");
+    if (option_compact_mode) {
+        fprintf(stdout,"Bank             Used   Free   Free%% \n"
+                       "----------       -----  -----  -----\n");
+    } else {
+        fprintf(stdout,"Bank           Range             Size   Used   Used%%  Free   Free%% \n"
+                       "----------     ----------------  -----  -----  -----  -----  -----\n");
+    }
 
     // Print all banks
     for (c = 0; c < p_bank_list->count; c++) {

--- a/src/common.c
+++ b/src/common.c
@@ -11,6 +11,7 @@ bool banks_display_areas        = false;
 bool banks_display_headers      = false;
 bool banks_display_minigraph    = false;
 bool banks_display_largegraph   = false;
+bool option_compact_mode        = false;
 bool option_display_asciistyle  = false;
 bool option_all_areas_exclusive = false;
 bool option_quiet_mode          = false;
@@ -42,6 +43,11 @@ void banks_output_show_minigraph(bool do_show) {
 // Turn on/off display of large usage graph per bank
 void banks_output_show_largegraph(bool do_show) {
     banks_display_largegraph = do_show;
+}
+
+// Turn on/off compact display mode
+void set_option_show_compact(bool value) {
+    option_compact_mode = value;
 }
 
 // Turn on/off whether to use ascii style

--- a/src/common.h
+++ b/src/common.h
@@ -25,6 +25,7 @@ extern bool banks_display_areas;
 extern bool banks_display_headers;
 extern bool banks_display_minigraph;
 extern bool banks_display_largegraph;
+extern bool option_compact_mode;
 extern bool option_all_areas_exclusive;
 extern bool option_quiet_mode;
 extern bool option_suppress_duplicates;
@@ -45,6 +46,7 @@ void set_option_input_source(int value);
 void set_option_area_sort(int value);
 void set_option_area_hide_size(uint32_t value);
 void set_option_display_asciistyle(bool value);
+void set_option_show_compact(bool value);
 
 int get_option_input_source(void);
 int get_option_area_sort(void);

--- a/src/romusage.c
+++ b/src/romusage.c
@@ -57,6 +57,7 @@ static void display_help(void) {
            "-q  : Quiet, no output except warnings and errors\n"
            "-R  : Return error code for Area warnings and errors \n"
            "\n"
+           "-sC : Enable compact mode, hiding nonessential columns.\n"
            "-sH : Show HEADER Areas (normally hidden)\n"
            "-nB : Hide warning banner (for .cdb output)\n"
            "-nA : Hide areas (shown by default in .cdb output)\n"

--- a/src/romusage.c
+++ b/src/romusage.c
@@ -110,6 +110,9 @@ int handle_args(int argc, char * argv[]) {
         } else if (strstr(argv[i], "-sH") == argv[i]) {
             banks_output_show_headers(true);
 
+        } else if (strstr(argv[i], "-sC") == argv[i]) {
+            set_option_show_compact(true);
+
         } else if (strstr(argv[i], "-nB") == argv[i]) {
             set_option_hide_banners(true);
 
@@ -182,7 +185,7 @@ void cleanup(void) {
 
 int main( int argc, char *argv[] )  {
 
-    int ret = EXIT_FAILURE; // Default to failure on exit    
+    int ret = EXIT_FAILURE; // Default to failure on exit
 
     // Register cleanup with exit handler
     atexit(cleanup);


### PR DESCRIPTION
Passing `-sC` gives you compact output, which removes nonessential information to keep the output width with `-g` under 80 columns.