### PR TITLE
Fix for macOS build action hanging (10.15 runner deprecated)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             name: Linux-x64
-          - os: macos-10.15
+          - os: macos-11
             name: MacOS-x64
     steps:
 


### PR DESCRIPTION
Action was hanging on macOS build (stuck in "queued" state with no other indication). Github Runner for 10.15 appears to be deprecated, trying change to macOS version 11